### PR TITLE
修复上传到 cos 的 tgz 包有问题的 bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,13 +46,22 @@ class OssWrapper {
   }
 
   async upload(filePath, options) {
+    if (typeof filePath === 'string') {
+      filePath = fs.createReadStream(filePath);
+    }
     return await this.uploadBuffer(filePath, options);
   }
 
   async uploadBuffer(content, options) {
     const key = trimKey(options.key);
-    const contentLength = content.length;
-    const body = bufferToReadStream(content);
+    let contentLength;
+    let body;
+    if (content instanceof fs.ReadStream) {
+      body = content;
+    } else {
+      contentLength = content.length;
+      body = bufferToReadStream(content);
+    }
     const params = {
       ...this.commonBucketConfig,
       Key: key,
@@ -69,7 +78,7 @@ class OssWrapper {
     if (typeof bytes === 'string') {
       bytes = Buffer.from(bytes);
     }
-    return await this.upload(bytes, options);
+    return await this.uploadBuffer(bytes, options);
   }
 
   async appendBytes(bytes, options) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cos-cnpm",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "tencent-cloud cos wrapper for cnpm",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
upload(filePath, options) 方法中 filePath 可能是本地路径字符串，需要先读取本地文件内容，再进行上传；否则，上传到 cos 的 tgz 包内容将只会是 filePath 路径字符串，安装的时候会报哈希校验失败的错误【EINTEGRITY】。